### PR TITLE
Add theme support

### DIFF
--- a/lib/jekyll/assets/env.rb
+++ b/lib/jekyll/assets/env.rb
@@ -193,6 +193,12 @@ module Jekyll
           end
         end
 
+        if jekyll.theme then
+          Config::DIRECTORIES.map do |name|
+            append_path Pathutil.new(format("#{jekyll.theme.assets_path}/%<name>s", name: name))
+          end
+        end
+
         paths
       end
 

--- a/lib/jekyll/assets/version.rb
+++ b/lib/jekyll/assets/version.rb
@@ -4,6 +4,6 @@
 
 module Jekyll
   module Assets
-    VERSION = "4.0.0.alpha"
+    VERSION = "4.0.0.alpha-theme.0"
   end
 end


### PR DESCRIPTION
Allows using `jekyll-assets` with a jekyll theme.

Put your assets in theme and use jekyll-assess like the assets in your repo.

E.g:
- put logo.js in /assets/js/logo.js in  your theme
- use the theme in your Jekyll project
- use `{% asset logo.js %}` as usual in your project
